### PR TITLE
fix props example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Vue.use(snowCalendar)
   :sources="sourceObject"
   :events="eventObject"
   :mode="modeString"
-  :mainCal="timeObject"
-  :refCal="timeObject"
-  :uiVisible="setObject"
+  :main-cal="timeObject"
+  :ref-cal="timeObject"
+  :ui-visible="setObject"
   :lang="langString"
 ></snowCalendar>
 ```


### PR DESCRIPTION
謝謝你做了這麼有趣的工具！感謝！
使用的時候發現一些問題，在此提出。

問題：

根據Vue2 官方文件 [components-props](https://vuejs.org/v2/guide/components-props.html#Prop-Casing-camelCase-vs-kebab-case)
props 在 html 內使用 in-dom 的方式時是不能使用camelCase的，會全部改為小寫，這樣就讀取不到正確的值。

修正：
更正Readme內的範例部份
設定方式如下：
```
<snowCalendar
  :sources="sourceObject"
  :events="eventObject"
  :mode="modeString"
  :main-cal="timeObject"
  :ref-cal="timeObject"
  :ui-visible="setObject"
  :lang="langString"
></snowCalendar>
```